### PR TITLE
ResourceRetriever::retrieve() should take url and headers as arguments

### DIFF
--- a/src/Command/RetrieveResourceCommand.php
+++ b/src/Command/RetrieveResourceCommand.php
@@ -86,7 +86,10 @@ class RetrieveResourceCommand extends Command
         $hasUnknownFailure = true;
 
         try {
-            $requestResponse = $this->resourceRetriever->retrieve($retrieveRequest);
+            $requestResponse = $this->resourceRetriever->retrieve(
+                $retrieveRequest->getUrl(),
+                $retrieveRequest->getHeaders()
+            );
 
             $httpResponse = $requestResponse->getResponse();
             $responseType = RetryDecider::TYPE_HTTP;

--- a/src/Services/ResourceRetriever.php
+++ b/src/Services/ResourceRetriever.php
@@ -4,13 +4,13 @@ namespace App\Services;
 
 use App\Exception\HttpTransportException;
 use App\Model\RequestResponse;
-use App\Model\RetrieveRequest;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\TransferStats;
+use webignition\HttpHeaders\Headers;
 
 class ResourceRetriever
 {
@@ -25,15 +25,18 @@ class ResourceRetriever
     }
 
     /**
-     * @param RetrieveRequest $retrieveRequest
+     * @param string $url
+     * @param Headers $headers
      *
      * @return RequestResponse
      *
      * @throws HttpTransportException
      */
-    public function retrieve(RetrieveRequest $retrieveRequest): RequestResponse
+    public function retrieve(string $url, ?Headers $headers = null): RequestResponse
     {
-        $request = new Request('GET', $retrieveRequest->getUrl(), $retrieveRequest->getHeaders()->toArray());
+        $headers = $headers ?? new Headers();
+
+        $request = new Request('GET', $url, $headers->toArray());
 
         $requestUri = $request->getUri();
         $response = null;

--- a/tests/Functional/Services/ResourceRetrieverTest.php
+++ b/tests/Functional/Services/ResourceRetrieverTest.php
@@ -3,7 +3,6 @@
 namespace App\Tests\Functional\Services;
 
 use App\Exception\HttpTransportException;
-use App\Model\RetrieveRequest;
 use App\Services\ResourceRetriever;
 use App\Tests\Functional\AbstractFunctionalTestCase;
 use App\Tests\Services\HttpMockHandler;
@@ -60,9 +59,7 @@ class ResourceRetrieverTest extends AbstractFunctionalTestCase
             'foo' => 'bar',
         ]);
 
-        $retrieveRequest = new RetrieveRequest('request_hash', 'http://example.com/', $headers);
-
-        $requestResponse = $this->resourceRetriever->retrieve($retrieveRequest);
+        $requestResponse = $this->resourceRetriever->retrieve('http://example.com/', $headers);
         $response = $requestResponse->getResponse();
         $this->assertSame($expectedResponseStatusCode, $response->getStatusCode());
 
@@ -160,9 +157,7 @@ class ResourceRetrieverTest extends AbstractFunctionalTestCase
             $http200Response,
         ]);
 
-        $retrieveRequest = new RetrieveRequest('request_hash', 'http://example.com/');
-
-        $requestResponse = $this->resourceRetriever->retrieve($retrieveRequest);
+        $requestResponse = $this->resourceRetriever->retrieve('http://example.com/');
         $request = $requestResponse->getRequest();
 
         $this->assertEquals('http://example.com/foo', $request->getUri());
@@ -185,10 +180,8 @@ class ResourceRetrieverTest extends AbstractFunctionalTestCase
     ) {
         $this->httpMockHandler->appendFixtures($httpFixtures);
 
-        $retrieveRequest = new RetrieveRequest('request_hash', 'http://example.com/');
-
         try {
-            $this->resourceRetriever->retrieve($retrieveRequest);
+            $this->resourceRetriever->retrieve('http://example.com/');
             $this->fail('HttpTransportException not thrown');
         } catch (HttpTransportException $transportException) {
             $this->assertSame($expectedTransportErrorCode, $transportException->getTransportErrorCode());


### PR DESCRIPTION
Fixes #191