### PR TITLE
CachedResourceFactory::create() should take requestHash and url as arguments

### DIFF
--- a/src/Command/RetrieveResourceCommand.php
+++ b/src/Command/RetrieveResourceCommand.php
@@ -136,7 +136,11 @@ class RetrieveResourceCommand extends Command
             if ($cachedResource) {
                 $this->cachedResourceFactory->updateResponse($cachedResource, $httpResponse);
             } else {
-                $cachedResource = $this->cachedResourceFactory->create($retrieveRequest, $httpResponse);
+                $cachedResource = $this->cachedResourceFactory->create(
+                    $retrieveRequest->getRequestHash(),
+                    $retrieveRequest->getUrl(),
+                    $httpResponse
+                );
             }
 
             $this->cachedResourceManager->update($cachedResource);

--- a/src/Services/CachedResourceFactory.php
+++ b/src/Services/CachedResourceFactory.php
@@ -3,13 +3,12 @@
 namespace App\Services;
 
 use App\Entity\CachedResource;
-use App\Model\RetrieveRequest;
 use Psr\Http\Message\ResponseInterface as HttpResponseInterface;
 use webignition\HttpHeaders\Headers;
 
 class CachedResourceFactory
 {
-    public function create(RetrieveRequest $retrieveRequest, HttpResponseInterface $response): ?CachedResource
+    public function create(string $requestHash, string $url, HttpResponseInterface $response): ?CachedResource
     {
         if (200 !== $response->getStatusCode()) {
             return null;
@@ -19,8 +18,8 @@ class CachedResourceFactory
 
         $this->updateResponse($cachedResource, $response);
 
-        $cachedResource->setRequestHash($retrieveRequest->getRequestHash());
-        $cachedResource->setUrl($retrieveRequest->getUrl());
+        $cachedResource->setRequestHash($requestHash);
+        $cachedResource->setUrl($url);
 
         return $cachedResource;
     }

--- a/tests/Functional/Command/RetrieveResourceCommandTest.php
+++ b/tests/Functional/Command/RetrieveResourceCommandTest.php
@@ -244,7 +244,8 @@ class RetrieveResourceCommandTest extends AbstractFunctionalTestCase
         $currentBody = 'current body content';
 
         $cachedResource = $cachedResourceFactory->create(
-            $this->retrieveRequest,
+            $this->retrieveRequest->getRequestHash(),
+            $this->retrieveRequest->getUrl(),
             new Response(200, $currentHeaders, $currentBody)
         );
 

--- a/tests/Functional/Command/SendResponseCommandTest.php
+++ b/tests/Functional/Command/SendResponseCommandTest.php
@@ -416,7 +416,11 @@ class SendResponseCommandTest extends AbstractFunctionalTestCase
     ): CachedResource {
         $httpResponse = new HttpResponse(200, $httpResponseHeaders, $httpResponseBody);
 
-        $cachedResource = $this->cachedResourceFactory->create($retrieveRequest, $httpResponse);
+        $cachedResource = $this->cachedResourceFactory->create(
+            $retrieveRequest->getRequestHash(),
+            $retrieveRequest->getUrl(),
+            $httpResponse
+        );
         $this->cachedResourceManager->update($cachedResource);
 
         return $cachedResource;

--- a/tests/Functional/MessageHandler/SendResponseHandlerTest.php
+++ b/tests/Functional/MessageHandler/SendResponseHandlerTest.php
@@ -355,7 +355,11 @@ class SendResponseHandlerTest extends AbstractFunctionalTestCase
     ): CachedResource {
         $httpResponse = new HttpResponse(200, $httpResponseHeaders, $httpResponseBody);
 
-        $cachedResource = $this->cachedResourceFactory->create($retrieveRequest, $httpResponse);
+        $cachedResource = $this->cachedResourceFactory->create(
+            $retrieveRequest->getRequestHash(),
+            $retrieveRequest->getUrl(),
+            $httpResponse
+        );
         $this->cachedResourceManager->update($cachedResource);
 
         return $cachedResource;

--- a/tests/Functional/Services/CachedResourceManagerTest.php
+++ b/tests/Functional/Services/CachedResourceManagerTest.php
@@ -85,6 +85,10 @@ class CachedResourceManagerTest extends AbstractFunctionalTestCase
         $retrieveRequest = new RetrieveRequest($requestHash, $url);
         $httpResponse = new Response(200, $httpResponseHeaders, $httpResponseBody);
 
-        return $this->cachedResourceFactory->create($retrieveRequest, $httpResponse);
+        return $this->cachedResourceFactory->create(
+            $retrieveRequest->getRequestHash(),
+            $retrieveRequest->getUrl(),
+            $httpResponse
+        );
     }
 }

--- a/tests/Unit/Services/CachedResourceFactoryTest.php
+++ b/tests/Unit/Services/CachedResourceFactoryTest.php
@@ -3,7 +3,6 @@
 namespace App\Tests\Unit\Services;
 
 use App\Entity\CachedResource;
-use App\Model\RetrieveRequest;
 use App\Services\CachedResourceFactory;
 use GuzzleHttp\Psr7\Response;
 use Psr\Http\Message\ResponseInterface as HttpResponseInterface;
@@ -30,9 +29,7 @@ class CachedResourceFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testCreateResponseNotSuccessResponse(HttpResponseInterface $response)
     {
-        $retrieveRequest = new RetrieveRequest('request_hash', 'http://example.com/');
-
-        $this->assertNull($this->cachedResourceFactory->create($retrieveRequest, $response));
+        $this->assertNull($this->cachedResourceFactory->create('request_hash', 'http://example.com/', $response));
     }
 
     public function createFromPsr7ResponseNotSuccessResponseDataProvider(): array
@@ -59,17 +56,18 @@ class CachedResourceFactoryTest extends \PHPUnit\Framework\TestCase
         array $expectedCachedResourceHeaders,
         string $expectedCachedResourceBody
     ) {
-        $retrieveRequest = new RetrieveRequest('request_hash', 'http://example.com/');
+        $requestHash = 'request_hash';
+        $url = 'http://example.com/';
 
-        $cachedResource = $this->cachedResourceFactory->create($retrieveRequest, $response);
+        $cachedResource = $this->cachedResourceFactory->create($requestHash, $url, $response);
 
         $cachedResourceHeaders = $cachedResource->getHeaders();
 
         $this->assertInstanceOf(Headers::class, $cachedResourceHeaders);
         $this->assertSame($expectedCachedResourceHeaders, $cachedResourceHeaders->toArray());
         $this->assertSame($expectedCachedResourceBody, $cachedResource->getBody());
-        $this->assertSame($retrieveRequest->getUrl(), $cachedResource->getUrl());
-        $this->assertSame($retrieveRequest->getRequestHash(), $cachedResource->getRequestHash());
+        $this->assertSame($url, $cachedResource->getUrl());
+        $this->assertSame($requestHash, $cachedResource->getRequestHash());
     }
 
     public function createSuccessDataProvider(): array
@@ -96,9 +94,7 @@ class CachedResourceFactoryTest extends \PHPUnit\Framework\TestCase
     {
         $response = new Response(200, ['foo' => 'bar'], 'response content');
 
-        $retrieveRequest = new RetrieveRequest('request_hash', 'http://example.com/');
-
-        $cachedResource = $this->cachedResourceFactory->create($retrieveRequest, $response);
+        $cachedResource = $this->cachedResourceFactory->create('request_hash', 'http://example.com/', $response);
 
         $this->assertSame($cachedResource->getHeaders()->toArray(), $response->getHeaders());
         $this->assertSame($cachedResource->getBody(), (string) $response->getBody());


### PR DESCRIPTION
Fixes #194